### PR TITLE
3.0.x security patches

### DIFF
--- a/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
+++ b/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
@@ -65,7 +65,7 @@ module HTML
 
     # A regular expression of the valid characters used to separate protocols like
     # the ':' in 'http://foo.com'
-    self.protocol_separator     = /:|(&#0*58)|(&#x70)|(%|&#37;)3A/
+    self.protocol_separator     = /:|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A/i
 
     # Specifies a Set of HTML attributes that can have URIs.
     self.uri_attributes         = Set.new(%w(href src cite action longdesc xlink:href lowsrc))
@@ -170,7 +170,7 @@ module HTML
 
     def contains_bad_protocols?(attr_name, value)
       uri_attributes.include?(attr_name) &&
-      (value =~ /(^[^\/:]*):|(&#0*58)|(&#x70)|(%|&#37;)3A/ && !allowed_protocols.include?(value.split(protocol_separator).first))
+      (value =~ /(^[^\/:]*):|(&#0*58)|(&#x70)|(&#x0*3a)|(%|&#37;)3A/i && !allowed_protocols.include?(value.split(protocol_separator).first.downcase.strip))
     end
   end
 end

--- a/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
+++ b/actionpack/lib/action_controller/vendor/html-scanner/html/sanitizer.rb
@@ -109,8 +109,8 @@ module HTML
       style = style.to_s.gsub(/url\s*\(\s*[^\s)]+?\s*\)\s*/, ' ')
 
       # gauntlet
-      if style !~ /^([:,;#%.\sa-zA-Z0-9!]|\w-\w|\'[\s\w]+\'|\"[\s\w]+\"|\([\d,\s]+\))*$/ ||
-          style !~ /^(\s*[-\w]+\s*:\s*[^:;]*(;|$)\s*)*$/
+      if style !~ /\A([:,;#%.\sa-zA-Z0-9!]|\w-\w|\'[\s\w]+\'|\"[\s\w]+\"|\([\d,\s]+\))*\z/ ||
+          style !~ /\A(\s*[-\w]+\s*:\s*[^:;]*(;|$)\s*)*\z/
         return ''
       end
 
@@ -121,7 +121,7 @@ module HTML
         elsif shorthand_css_properties.include?(prop.split('-')[0].downcase)
           unless val.split().any? do |keyword|
             !allowed_css_keywords.include?(keyword) &&
-              keyword !~ /^(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$/
+              keyword !~ /\A(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)\z/
           end
             clean << prop + ': ' + val + ';'
           end

--- a/actionpack/test/template/html-scanner/sanitizer_test.rb
+++ b/actionpack/test/template/html-scanner/sanitizer_test.rb
@@ -168,6 +168,7 @@ class SanitizerTest < ActionController::TestCase
    %(<IMG SRC="jav&#x0A;ascript:alert('XSS');">),
    %(<IMG SRC="jav&#x0D;ascript:alert('XSS');">),
    %(<IMG SRC=" &#14;  javascript:alert('XSS');">),
+   %(<IMG SRC="javascript&#x3a;alert('XSS');">),
    %(<IMG SRC=`javascript:alert("RSnake says, 'XSS'")`>)].each_with_index do |img_hack, i|
     define_method "test_should_not_fall_for_xss_image_hack_#{i+1}" do
       assert_sanitized img_hack, "<img>"
@@ -271,6 +272,15 @@ class SanitizerTest < ActionController::TestCase
 
   def test_should_sanitize_neverending_attribute
     assert_sanitized "<span class=\"\\", "<span class=\"\\\">"
+  end
+
+  def test_x03a
+    assert_sanitized %(<a href="javascript&#x3a;alert('XSS');">), "<a>"
+    assert_sanitized %(<a href="javascript&#x003a;alert('XSS');">), "<a>"
+    assert_sanitized %(<a href="http&#x3a;//legit">), %(<a href="http://legit">)
+    assert_sanitized %(<a href="javascript&#x3A;alert('XSS');">), "<a>"
+    assert_sanitized %(<a href="javascript&#x003A;alert('XSS');">), "<a>"
+    assert_sanitized %(<a href="http&#x3A;//legit">), %(<a href="http://legit">)
   end
 
 protected

--- a/actionpack/test/template/html-scanner/sanitizer_test.rb
+++ b/actionpack/test/template/html-scanner/sanitizer_test.rb
@@ -248,6 +248,11 @@ class SanitizerTest < ActionController::TestCase
     assert_equal '', sanitize_css(raw)
   end
 
+  def test_should_sanitize_across_newlines
+    raw = %(\nwidth:\nexpression(alert('XSS'));\n)
+    assert_equal '', sanitize_css(raw)
+  end
+
   def test_should_sanitize_img_vbscript
     assert_sanitized %(<img src='vbscript:msgbox("XSS")' />), '<img />'
   end

--- a/activesupport/lib/active_support/xml_mini/jdom.rb
+++ b/activesupport/lib/active_support/xml_mini/jdom.rb
@@ -38,6 +38,12 @@ module ActiveSupport
         {}
       else
         @dbf = DocumentBuilderFactory.new_instance
+        # secure processing of java xml
+        # http://www.ibm.com/developerworks/xml/library/x-tipcfsx/index.html
+        @dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        @dbf.setFeature("http://xml.org/sax/features/external-general-entities", false)
+        @dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+        @dbf.setFeature(javax.xml.XMLConstants::FEATURE_SECURE_PROCESSING, true)
         xml_string_reader = StringReader.new(data)
         xml_input_source = InputSource.new(xml_string_reader)
         doc = @dbf.new_document_builder.parse(xml_input_source)

--- a/activesupport/test/fixtures/xml/jdom_doctype.dtd
+++ b/activesupport/test/fixtures/xml/jdom_doctype.dtd
@@ -1,0 +1,1 @@
+<!ENTITY a "external entity">

--- a/activesupport/test/fixtures/xml/jdom_entities.txt
+++ b/activesupport/test/fixtures/xml/jdom_entities.txt
@@ -1,0 +1,1 @@
+<!ENTITY a "hello">

--- a/activesupport/test/fixtures/xml/jdom_include.txt
+++ b/activesupport/test/fixtures/xml/jdom_include.txt
@@ -1,0 +1,1 @@
+include me

--- a/activesupport/test/xml_mini/jdom_engine_test.rb
+++ b/activesupport/test/xml_mini/jdom_engine_test.rb
@@ -3,9 +3,10 @@ if RUBY_PLATFORM =~ /java/
   require 'active_support/xml_mini'
   require 'active_support/core_ext/hash/conversions'
 
-
-  class JDOMEngineTest < Test::Unit::TestCase
+  class JDOMEngineTest < ActiveSupport::TestCase
     include ActiveSupport
+
+    FILES_DIR = File.dirname(__FILE__) + '/../fixtures/xml'
 
     def setup
       @default_backend = XmlMini.backend
@@ -31,10 +32,41 @@ if RUBY_PLATFORM =~ /java/
        assert_equal 'image/png', file.content_type
     end
 
+    def test_not_allowed_to_expand_entities_to_files
+      attack_xml = <<-EOT
+      <!DOCTYPE member [
+        <!ENTITY a SYSTEM "file://#{FILES_DIR}/jdom_include.txt">
+      ]>
+      <member>x&a;</member>
+      EOT
+      assert_equal 'x', Hash.from_xml(attack_xml)["member"]
+    end
+
+  def test_not_allowed_to_expand_parameter_entities_to_files
+      attack_xml = <<-EOT
+      <!DOCTYPE member [
+        <!ENTITY % b SYSTEM "file://#{FILES_DIR}/jdom_entities.txt">
+        %b;
+      ]>
+      <member>x&a;</member>
+      EOT
+      assert_raise Java::OrgXmlSax::SAXParseException do
+        assert_equal 'x', Hash.from_xml(attack_xml)["member"]
+      end
+    end
+
+
+    def test_not_allowed_to_load_external_doctypes
+      attack_xml = <<-EOT
+      <!DOCTYPE member SYSTEM "file://#{FILES_DIR}/jdom_doctype.dtd">
+      <member>x&a;</member>
+      EOT
+      assert_equal 'x', Hash.from_xml(attack_xml)["member"]
+    end
+
     def test_exception_thrown_on_expansion_attack
-      assert_raise NativeException do
+      assert_raise Java::OrgXmlSax::SAXParseException do
         attack_xml = <<-EOT
-      <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE member [
         <!ENTITY a "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
         <!ENTITY b "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">


### PR DESCRIPTION
3 of the 4 recent security vulnerabilities affect 3.0.x. Let us know if you'd like us to continue sending PRs for 3.0.x in the future.

@mkelley33 
