### PR TITLE
Avoid "Digest::Digest is deprecated; Use Digest"

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -73,7 +73,7 @@ module ActiveSupport
 
       def generate_digest(data)
         require 'openssl' unless defined?(OpenSSL)
-        OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new(@digest), @secret, data)
+        OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new(@digest), @secret, data)
       end
   end
 end


### PR DESCRIPTION
When running on Ruby 2.2. Context here http://stackoverflow.com/questions/21184960/ruby-digestdigest-is-deprecated-use-digest/21185739#21185739 and here https://github.com/ruby/ruby/pull/446
