### PR TITLE
Remove warning when using html_escape with Ruby 1.9.

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -5,21 +5,32 @@ class ERB
     HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&#39;' }
     JSON_ESCAPE = { '&' => '\u0026', '>' => '\u003E', '<' => '\u003C' }
 
-    # A utility method for escaping HTML tag characters.
-    # This method is also aliased as <tt>h</tt>.
-    #
-    # In your ERB templates, use this method to escape any unsafe content. For example:
-    #   <%=h @person.name %>
-    #
-    # ==== Example:
-    #   puts html_escape("is a > 0 & a < 10?")
-    #   # => is a &gt; 0 &amp; a &lt; 10?
-    def html_escape(s)
-      s = s.to_s
-      if s.html_safe?
-        s
-      else
-        s.gsub(/[&"'><]/n) { |special| HTML_ESCAPE[special] }.html_safe
+    if RUBY_VERSION >= '1.9'
+      # A utility method for escaping HTML tag characters.
+      # This method is also aliased as <tt>h</tt>.
+      #
+      # In your ERB templates, use this method to escape any unsafe content. For example:
+      #   <%=h @person.name %>
+      #
+      # ==== Example:
+      #   puts html_escape("is a > 0 & a < 10?")
+      #   # => is a &gt; 0 &amp; a &lt; 10?
+      def html_escape(s)
+        s = s.to_s
+        if s.html_safe?
+          s
+        else
+          s.gsub(/[&"'><]/, HTML_ESCAPE).html_safe
+        end
+      end
+    else
+      def html_escape(s) #:nodoc:
+        s = s.to_s
+        if s.html_safe?
+          s
+        else
+          s.gsub(/[&"'><]/n) { |special| HTML_ESCAPE[special] }.html_safe
+        end
       end
     end
 


### PR DESCRIPTION
This is 4f12e3a3a5d28b63a74344cc8997b8466d276277 from `rails/rails` cherry-picked on top of the `lts` branch.

``` bash
git remote add rails https://github.com/rails/rails.git
git fetch rails
git cherry-pick 4f12e3a3a5d28b63a74344cc8997b8466d276277
```

It's trivial to apply yourself, and it should apply cleanly to the `3-0` branches, if missing.

---

This removes the very painful `activesupport/lib/active_support/core_ext/string/output_safety.rb:22: warning: regexp match /.../n against to UTF-8 string` warning that is printed to `stderr` every time HTML is escaped. It's filling up all my logs, making them unusable.

Most people should be on 1.9 now, so this should be a problem for a lot of people.

---

I saw the README saying that pull requests should be kept to just security issues, but as rails/rails#7430 show, this warning _appeared_ after a security patch and wasn't there before. IMO, the security patch had a bug, and this fixes that bug. I hope you find this reasoning satisfactory.
