### PR TITLE
fix ruby 2.2 warning: circular argument reference - now

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -247,7 +247,7 @@ module ActiveSupport
     #
     #   Time.zone.now                 # => Fri, 31 Dec 1999 14:00:00 HST -10:00
     #   Time.zone.parse('22:30:00')   # => Fri, 31 Dec 1999 22:30:00 HST -10:00
-    def parse(str, now=now)
+    def parse(str, now=now())
       date_parts = Date._parse(str)
       return if date_parts.blank?
       time = Time.parse(str, now) rescue DateTime.parse(str)


### PR DESCRIPTION
This fix is related to pull request https://github.com/makandra/rails/pull/3.
