### PR TITLE
remove deprecation warnings with ruby 2.4

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -54,9 +54,17 @@ class Object
   end
 end
 
-class Fixnum
-  def html_safe?
-    true
+if RUBY_VERSION >= '2.4.0'
+  class Integer
+    def html_safe?
+      true
+    end
+  end
+else
+  class Fixnum
+    def html_safe?
+      true
+    end
   end
 end
 

--- a/activesupport/lib/active_support/vendor/builder-2.1.2/builder/xchar.rb
+++ b/activesupport/lib/active_support/vendor/builder-2.1.2/builder/xchar.rb
@@ -19,7 +19,12 @@ end
 
 if ! defined?(Builder::XChar)
   Builder.check_for_name_collision(String, "to_xs")
-  Builder.check_for_name_collision(Fixnum, "xchr")
+  
+  if RUBY_VERSION >= '2.4.0'
+    Builder.check_for_name_collision(Integer, "xchr")
+  else
+    Builder.check_for_name_collision(Fixnum, "xchr")
+  end
 end
 
 ######################################################################
@@ -86,16 +91,33 @@ end
 ######################################################################
 # Enhance the Fixnum class with a XML escaped character conversion.
 #
-class Fixnum
-  XChar = Builder::XChar if ! defined?(XChar)
 
-  # XML escaped version of chr
-  def xchr
-    n = XChar::CP1252[self] || self
-    case n when *XChar::VALID
-      XChar::PREDEFINED[n] or (n<128 ? n.chr : "&##{n};")
-    else
-      '*'
+if RUBY_VERSION >= '2.4.0'
+  class Integer
+    XChar = Builder::XChar if ! defined?(XChar)
+
+    # XML escaped version of chr
+    def xchr
+      n = XChar::CP1252[self] || self
+      case n when *XChar::VALID
+        XChar::PREDEFINED[n] or (n<128 ? n.chr : "&##{n};")
+      else
+        '*'
+      end
+    end
+  end
+else
+  class Fixnum
+    XChar = Builder::XChar if ! defined?(XChar)
+
+    # XML escaped version of chr
+    def xchr
+      n = XChar::CP1252[self] || self
+      case n when *XChar::VALID
+        XChar::PREDEFINED[n] or (n<128 ? n.chr : "&##{n};")
+      else
+        '*'
+      end
     end
   end
 end


### PR DESCRIPTION
Ruby 2.4 unified Fixnum and Bignum into a single class Integer.