### PR TITLE
ensuring lts_gem_handling gets called via raketask

### DIFF
--- a/railties/lib/tasks/gems.rake
+++ b/railties/lib/tasks/gems.rake
@@ -1,3 +1,5 @@
+require 'lts_gem_handling'
+
 if Rails.enable_gem_handling?
 
   desc "List the gems that this rails application depends on"


### PR DESCRIPTION
Raketasks fail at the moment due to the enable_gem_handling? method. 

I've added the require to load the patch before the gems.rake task which fixes it, although perhaps there is a cleaner way.