### PR TITLE
Allows to be used with Passenger

### DIFF
--- a/actionpack/lib/action_controller/request.rb
+++ b/actionpack/lib/action_controller/request.rb
@@ -539,7 +539,7 @@ EOM
       hash
     end
 
-    def parse_query(qs)
+    def parse_query(qs, delimiters = nil)
       deep_munge(super)
     end
   end


### PR DESCRIPTION
Passenger sends in an extra parameter to parse_query that is a list of delimiters.  This can be safely ignored, but, since it is not expecting the parameter, it crashes without this.