### PR TITLE
Encode logger messages to valid encoding

### DIFF
--- a/activesupport/lib/active_support/buffered_logger.rb
+++ b/activesupport/lib/active_support/buffered_logger.rb
@@ -63,6 +63,11 @@ module ActiveSupport
       # If a newline is necessary then create a new message ending with a newline.
       # Ensures that the original message is not mutated.
       message = "#{message}\n" unless message[-1] == ?\n
+      # We should encode message to encoding appropriate for writing to log file,
+      #   which is `Encoding.default_internal` because log file is created without any encoding options.
+      # Otherwise we receive exception during buffer flush stage
+      #   which will occur forever in current rails process, for all ongoing requests.
+      message = message.encode( Encoding.default_internal, :invalid => :replace, :undef => :replace )      
       buffer << message
       auto_flush
       message


### PR DESCRIPTION
If a string with invalid encoding is passed to BufferedLogger's add method (for example via logger.info), it will generate an exception at logger flush stage. Furthermore, due to this exception the invalid content will not be removed from the buffer, and exception will occur again on next flushes. This practially breaks current rails process from servicing requests.

For example, put following action into any controller, with BufferedLogger enabled for application:
```
  def test
    logger.info "123ыыы".force_encoding(Encoding::ASCII_8BIT)
    render :text => "333"
  end
```
Call it once, and observe how all ongoing requests will not be served by application.

p.s. This situation is not fun, because `OkJson` module, which is used to parse request's incoming json parameters by default, prints `raw_post` content to the logger if it fails to parse that content. That was our case.