### PR TITLE
fix: toggle deprecated option in pg_dump removed in PG 9.5.0

### DIFF
--- a/railties/lib/tasks/databases.rake
+++ b/railties/lib/tasks/databases.rake
@@ -283,7 +283,7 @@ namespace :db do
         ENV['PGPASSWORD'] = abcs[RAILS_ENV]["password"].to_s if abcs[RAILS_ENV]["password"]
         search_path = abcs[RAILS_ENV]["schema_search_path"]
         search_path = "--schema=#{search_path}" if search_path
-        `pg_dump -i -U "#{abcs[RAILS_ENV]["username"]}" -s -x -O -f db/#{RAILS_ENV}_structure.sql #{search_path} #{abcs[RAILS_ENV]["database"]}`
+        `pg_dump #{ActiveRecord::Base.connection.send(:postgresql_version) < 90500 ? "-i" : ""} -U "#{abcs[RAILS_ENV]["username"]}" -s -x -O -f db/#{RAILS_ENV}_structure.sql #{search_path} #{abcs[RAILS_ENV]["database"]}`
         raise "Error dumping database" if $?.exitstatus == 1
       when "sqlite", "sqlite3"
         dbfile = abcs[RAILS_ENV]["database"] || abcs[RAILS_ENV]["dbfile"]


### PR DESCRIPTION
# Description
Removing option `-i/--ignore-version` used in `db:structure:dump` from `pg_dump` when using Postgres >= 9.5

> Remove the long-ignored -i/--ignore-version option from pg_dump, pg_dumpall, and pg_restore (Fujii Masao)
>
> https://www.postgresql.org/docs/release/9.5.0/